### PR TITLE
Update password to store hash only

### DIFF
--- a/sample_listing.json
+++ b/sample_listing.json
@@ -13,17 +13,9 @@
     "images": [],
     "author": "Harrison",
     "password": {
-        "hash": {
-            "$binary": {
-                "base64": "JDJiJDEyJE1TYi8zOVJORmF2OU5IeUpCbU1Qd3VpRGVRNWFhek9lWXRnSnprSWxkbVYyRjB3MnV5Qzky",
-                "subType": "00"
-            }
-        },
-        "salt": {
-            "$binary": {
-                "base64": "JDJiJDEyJE1TYi8zOVJORmF2OU5IeUpCbU1Qd3U=",
-                "subType": "00"
-            }
+        "$binary": {
+            "base64": "JDJiJDEyJE1TYi8zOVJORmF2OU5IeUpCbU1Qd3VpRGVRNWFhek9lWXRnSnprSWxkbVYyRjB3MnV5Qzky",
+            "subType": "00"
         }
     },
     "questions": [


### PR DESCRIPTION
Bcrypt stores the salt with the hash, so storing the salt separately was redundant.