### PR TITLE
nit: Persist search query after page navigation

### DIFF
--- a/index.py
+++ b/index.py
@@ -3,7 +3,7 @@ import pymongo
 from db import listings_collection
 from base64 import b64encode
 
-LISTINGS_PER_PAGE = 5 # for testing, probably will be 20 or something in prod
+LISTINGS_PER_PAGE = 1 # for testing, probably will be 20 or something in prod
 
 def index():
     try:
@@ -29,4 +29,9 @@ def index():
 
     del listings[LISTINGS_PER_PAGE:]
     next_page = page + 1 if num_listings > LISTINGS_PER_PAGE else -1
-    return render_template('index.html', listings = listings, prev_page = page - 1, next_page = next_page)
+    return render_template(
+        'index.html',
+        listings = listings,
+        prev_page = page - 1,
+        next_page = next_page,
+        search = request.args["search"] if "search" in request.args.keys() else "")

--- a/listing_create.py
+++ b/listing_create.py
@@ -2,8 +2,6 @@ from flask import render_template, request, redirect, url_for
 from db import listings_collection
 import time
 import bcrypt
-from bson.binary import Binary
-from bson import BSON
 
 ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg', 'gif'}
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -33,10 +33,10 @@
 
     <div>
         {% if prev_page != 0 %}
-        <a href="/?page={{prev_page}}">Previous page</a>
+        <a href="/?page={{prev_page}}&search={{search}}">Previous page</a>
         {% endif %}
         {% if next_page != -1 %}
-        <a href="/?page={{next_page}}">Next page</a>
+        <a href="/?page={{next_page}}&search={{search}}">Next page</a>
         {% endif %}
     </div>
 </body>


### PR DESCRIPTION
Before, if you searched something and navigated to the next page, it would forget what you had looked up. With this fix, navigating to another page after looking something up keeps what you had looked up.